### PR TITLE
feat(deploy): migrate dev to Cloudflare Pages

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,25 +1,41 @@
-name: Deploy to All-Inkl (Development)
+name: Deploy develop to Cloudflare Pages
 
 on:
   push:
     branches: [develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: dev-deploy
+  cancel-in-progress: true
+
 jobs:
-  build-and-deploy:
-    name: Deploy to All-Inkl
+  deploy:
+    name: wrangler pages deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      
-      - name: Deploy to All-Inkl (Development)
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          server: ${{ secrets.DEV_HOST }}
-          username: ${{ secrets.DEV_USER }}
-          password: ${{ secrets.DEV_PASSWORD }}
-          exclude: |
-            **/.git*
-            **/.git*/**
-            **/node_modules/**
+          node-version: "22"
+
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          wrangler pages deploy . \
+            --project-name=deuro-landing-page-dev \
+            --branch=develop \
+            --commit-hash=${{ github.sha }} \
+            --commit-message="${{ github.event.head_commit.message }}"


### PR DESCRIPTION
Replace FTP-Deploy-Action targeting All-Inkl with wrangler-based Direct Upload to Cloudflare Pages, matching the prd.yaml change merged earlier today.

Pages project: `deuro-landing-page-dev` (production_branch=develop). Paired with a Terraform change in DFXServer/server that creates the project and switches the dev.* DNS record from `A 85.13.138.57` / `CNAME w020e6de.kasserver.com` to `CNAME deuro-landing-page-dev.pages.dev`.

## Test plan

After the Terraform change is applied + this PR is merged:
- [ ] `curl -sI https://dev.<domain>/` → 200